### PR TITLE
feat: guard victory condition - only show win screen when goal is reached

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -129,6 +129,8 @@ script.on_event( defines.events.on_research_finished, Silo.onResearchFinished )
 
 script.on_event( defines.events.on_rocket_launched, Silo.onRocketLaunched )
 
+script.on_event( defines.events.on_pre_scenario_finished, Silo.onPreScenarioFinished )
+
 if Utils.getStartupSetting( "em_dev_mode" ) then
   script.on_event( "em-reload-mods", Utils.reload_mods )
   script.on_event( "em-run-function", run_test_function )

--- a/scripts/silo.lua
+++ b/scripts/silo.lua
@@ -277,6 +277,19 @@ end
 
 -------------------------------------------------------------------------------
 
+function Silo.onPreScenarioFinished(event)
+  -- Guard against premature victory - only allow win if the mod's goal is met
+  if not event.player_won then return end
+  
+  local remaining_launches = Utils.calculateRemainingLaunches()
+  if remaining_launches > 0 then
+    -- Goal not yet reached, cancel the victory
+    game.reset_game_state()
+  end
+end
+
+-------------------------------------------------------------------------------
+
 function Silo.onResearchFinished(event)
   if not event then return end
   if not event.research then return end


### PR DESCRIPTION
Ensures first rocket launch does not trigger victory unless it's the final launch
- Add onPreScenarioFinished handler to validate victory conditions
- Block premature victory if remaining launches > 0